### PR TITLE
Azure DPS provisioning support and example

### DIFF
--- a/cloud-support/azure-iot/azure-iot-sdk-c/custom_hsm_twilio.cpp
+++ b/cloud-support/azure-iot/azure-iot-sdk-c/custom_hsm_twilio.cpp
@@ -22,42 +22,36 @@
 
 #include "custom_hsm_twilio.h"
 
-typedef struct TWILIO_TRUST_ONBOARD_HSM_INFO_TAG
-{
-    const char* device_path;
-    const char* sim_pin;
-    int signing;
-    const char* certificate;
-    const char* common_name;
-    const char* key;
-    TLSIO_CRYPTODEV_PKEY* signing_key;
+typedef struct TWILIO_TRUST_ONBOARD_HSM_INFO_TAG {
+  const char* device_path;
+  const char* sim_pin;
+  int signing;
+  const char* certificate;
+  const char* common_name;
+  const char* key;
+  TLSIO_CRYPTODEV_PKEY* signing_key;
 } TWILIO_TRUST_ONBOARD_HSM_INFO;
 
-int hsm_client_x509_init()
-{
-    return 0;
+int hsm_client_x509_init() {
+  return 0;
 }
 
-void hsm_client_x509_deinit()
-{
+void hsm_client_x509_deinit() {
 }
 
-int hsm_client_tpm_init()
-{
-    return 0;
+int hsm_client_tpm_init() {
+  return 0;
 }
 
-void hsm_client_tpm_deinit()
-{
+void hsm_client_tpm_deinit() {
 }
 
-static int subjectName(const char *cert, size_t certLen, char **subjectName)
-{
+static int subjectName(const char* cert, size_t certLen, char** subjectName) {
   BIO* certBio = BIO_new(BIO_s_mem());
   BIO_write(certBio, cert, certLen);
-  STACK_OF(X509_INFO) *certstack;
-  X509_INFO *stack_item = NULL;
-  X509_NAME *certsubject = NULL;
+  STACK_OF(X509_INFO) * certstack;
+  X509_INFO* stack_item  = NULL;
+  X509_NAME* certsubject = NULL;
   int i;
 
   certstack = PEM_X509_INFO_read_bio(certBio, NULL, NULL, NULL);
@@ -73,12 +67,11 @@ static int subjectName(const char *cert, size_t certLen, char **subjectName)
     stack_item = sk_X509_INFO_value(certstack, i);
 
     certsubject = X509_get_subject_name(stack_item->x509);
-    X509_NAME_get_text_by_NID(certsubject, NID_commonName,
-        subject_cn, 256);
-    cert_version = (X509_get_version(stack_item->x509)+1);
+    X509_NAME_get_text_by_NID(certsubject, NID_commonName, subject_cn, 256);
+    cert_version = (X509_get_version(stack_item->x509) + 1);
 
     if (i == 0) {
-      *subjectName = (char *)malloc(sizeof(char) * (strlen(subject_cn) + 1));
+      *subjectName = (char*)malloc(sizeof(char) * (strlen(subject_cn) + 1));
       strcpy(*subjectName, subject_cn);
     }
   }
@@ -89,8 +82,7 @@ static int subjectName(const char *cert, size_t certLen, char **subjectName)
   return EXIT_SUCCESS;
 }
 
-static int populate_cert(TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info, const char* device_path, const char* pin)
-{
+static int populate_cert(TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info, const char* device_path, const char* pin) {
   int RESULT = 0;
 
   if (hsm_info->certificate != nullptr) {
@@ -111,18 +103,17 @@ static int populate_cert(TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info, const char* de
     (void)fprintf(stderr, "Failed reading certificate\r\n");
     RESULT = 1;
   } else {
-    hsm_info->certificate = (const char *)malloc(cert_size+1);
-    memcpy((void *)(hsm_info->certificate), cert, cert_size);
-    ((char *)hsm_info->certificate)[cert_size] = '\0';
+    hsm_info->certificate = (const char*)malloc(cert_size + 1);
+    memcpy((void*)(hsm_info->certificate), cert, cert_size);
+    ((char*)hsm_info->certificate)[cert_size] = '\0';
   }
 
-  (void)subjectName((const char *)cert, cert_size, (char **)&(hsm_info->common_name));
+  (void)subjectName((const char*)cert, cert_size, (char**)&(hsm_info->common_name));
 
   return RESULT;
 }
 
-static int populate_key(TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info, const char* device_path, const char* pin)
-{
+static int populate_key(TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info, const char* device_path, const char* pin) {
   int RESULT = 0;
 
   if (hsm_info->key != nullptr) {
@@ -139,9 +130,9 @@ static int populate_key(TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info, const char* dev
     (void)fprintf(stderr, "Failed reading private key\r\n");
     RESULT = 1;
   } else {
-    hsm_info->key = (const char *)malloc(pk_size+1);
-    memcpy((void *)(hsm_info->key), pk, pk_size);
-    ((char *)hsm_info->key)[pk_size] = '\0';
+    hsm_info->key = (const char*)malloc(pk_size + 1);
+    memcpy((void*)(hsm_info->key), pk, pk_size);
+    ((char*)hsm_info->key)[pk_size] = '\0';
   }
 
   return RESULT;
@@ -193,19 +184,18 @@ static int hsm_signing_destroy(void* priv) {
   return 1;
 }
 
-static int populate_signing_key(TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info, const char* device_path, const char* pin)
-{
+static int populate_signing_key(TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info, const char* device_path, const char* pin) {
   if (hsm_info->signing_key != nullptr) {
     return 0;
   }
-  hsm_info->signing_key = (TLSIO_CRYPTODEV_PKEY *)malloc(sizeof(TLSIO_CRYPTODEV_PKEY));
+  hsm_info->signing_key = (TLSIO_CRYPTODEV_PKEY*)malloc(sizeof(TLSIO_CRYPTODEV_PKEY));
   if (hsm_info->signing_key == NULL) {
     return 1;
   }
-  hsm_info->signing_key->sign = hsm_signing_sign;
-  hsm_info->signing_key->decrypt = hsm_signing_decrypt;
-  hsm_info->signing_key->destroy = hsm_signing_destroy;
-  hsm_info->signing_key->type = TLSIO_CRYPTODEV_PKEY_TYPE_RSA; // TODO: ECC support
+  hsm_info->signing_key->sign         = hsm_signing_sign;
+  hsm_info->signing_key->decrypt      = hsm_signing_decrypt;
+  hsm_info->signing_key->destroy      = hsm_signing_destroy;
+  hsm_info->signing_key->type         = TLSIO_CRYPTODEV_PKEY_TYPE_RSA;  // TODO: ECC support
   hsm_info->signing_key->private_data = hsm_info;
 
   tobInitialize(device_path);
@@ -213,144 +203,110 @@ static int populate_signing_key(TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info, const c
   return 0;
 }
 
-static HSM_CLIENT_HANDLE custom_hsm_create()
-{
+static HSM_CLIENT_HANDLE custom_hsm_create() {
   HSM_CLIENT_HANDLE result;
-  TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info = (TWILIO_TRUST_ONBOARD_HSM_INFO *)malloc(sizeof(TWILIO_TRUST_ONBOARD_HSM_INFO));
+  TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info =
+      (TWILIO_TRUST_ONBOARD_HSM_INFO*)malloc(sizeof(TWILIO_TRUST_ONBOARD_HSM_INFO));
   memset(hsm_info, 0, sizeof(TWILIO_TRUST_ONBOARD_HSM_INFO));
-  if (hsm_info == NULL)
-  {
+  if (hsm_info == NULL) {
     (void)fprintf(stderr, "Failed allocating hsm info\r\n");
     result = NULL;
-  }
-  else
-  {
+  } else {
     result = hsm_info;
   }
 
   return result;
 }
 
-static void custom_hsm_destroy(HSM_CLIENT_HANDLE handle)
-{
+static void custom_hsm_destroy(HSM_CLIENT_HANDLE handle) {
   fprintf(stderr, "destroying custom hsm\n");
-    if (handle != NULL)
-    {
-        TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info = (TWILIO_TRUST_ONBOARD_HSM_INFO*)handle;
-        // Free anything that has been allocated in this module
-        if (hsm_info->device_path != nullptr) free((void *)hsm_info->device_path);
-        if (hsm_info->sim_pin!= nullptr) free((void *)hsm_info->sim_pin);
-        if (hsm_info->certificate != nullptr) free((void *)hsm_info->certificate);
-        if (hsm_info->key != nullptr) free((void *)hsm_info->key);
-        free(hsm_info);
-    }
+  if (handle != NULL) {
+    TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info = (TWILIO_TRUST_ONBOARD_HSM_INFO*)handle;
+    // Free anything that has been allocated in this module
+    if (hsm_info->device_path != nullptr) free((void*)hsm_info->device_path);
+    if (hsm_info->sim_pin != nullptr) free((void*)hsm_info->sim_pin);
+    if (hsm_info->certificate != nullptr) free((void*)hsm_info->certificate);
+    if (hsm_info->key != nullptr) free((void*)hsm_info->key);
+    free(hsm_info);
+  }
 }
 
-static char* custom_hsm_get_certificate(HSM_CLIENT_HANDLE handle)
-{
-    char* result;
-    if (handle == NULL)
-    {
-        (void)fprintf(stderr, "Invalid handle value specified\r\n");
-        result = NULL;
-    }
-    else
-    {
-        TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info = (TWILIO_TRUST_ONBOARD_HSM_INFO*)handle;
-        if (hsm_info->certificate == NULL)
-        {
-          if (populate_cert(hsm_info, hsm_info->device_path, hsm_info->sim_pin) != 0) {
-            (void)fprintf(stderr, "Failed reading certificate\r\n");
-            result = NULL;
-          }
-        }
-        if (hsm_info->certificate == NULL)
-        {
-          result = NULL;
-        }
-        else
-        {
-          // TODO: Malloc the certificate for the iothub sdk to free
-          // this value will be sent unmodified to the tlsio
-          // layer to be processed
-          size_t len = strlen(hsm_info->certificate);
-          if ((result = (char*)malloc(len + 1)) == NULL)
-          {
-            (void)fprintf(stderr, "Failure allocating certificate\r\n");
-            result = NULL;
-          }
-          else
-          {
-            strcpy(result, hsm_info->certificate);
-          }
-        }
-    }
-    return result;
-}
-
-static char* custom_hsm_get_key(HSM_CLIENT_HANDLE handle)
-{
+static char* custom_hsm_get_certificate(HSM_CLIENT_HANDLE handle) {
   char* result;
-  if (handle == NULL)
-  {
+  if (handle == NULL) {
     (void)fprintf(stderr, "Invalid handle value specified\r\n");
     result = NULL;
+  } else {
+    TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info = (TWILIO_TRUST_ONBOARD_HSM_INFO*)handle;
+    if (hsm_info->certificate == NULL) {
+      if (populate_cert(hsm_info, hsm_info->device_path, hsm_info->sim_pin) != 0) {
+        (void)fprintf(stderr, "Failed reading certificate\r\n");
+        result = NULL;
+      }
+    }
+    if (hsm_info->certificate == NULL) {
+      result = NULL;
+    } else {
+      // TODO: Malloc the certificate for the iothub sdk to free
+      // this value will be sent unmodified to the tlsio
+      // layer to be processed
+      size_t len = strlen(hsm_info->certificate);
+      if ((result = (char*)malloc(len + 1)) == NULL) {
+        (void)fprintf(stderr, "Failure allocating certificate\r\n");
+        result = NULL;
+      } else {
+        strcpy(result, hsm_info->certificate);
+      }
+    }
   }
-  else
-  {
+  return result;
+}
+
+static char* custom_hsm_get_key(HSM_CLIENT_HANDLE handle) {
+  char* result;
+  if (handle == NULL) {
+    (void)fprintf(stderr, "Invalid handle value specified\r\n");
+    result = NULL;
+  } else {
     TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info = (TWILIO_TRUST_ONBOARD_HSM_INFO*)handle;
     if (!hsm_info->signing) {
-      if (hsm_info->key == NULL)
-      {
+      if (hsm_info->key == NULL) {
         if (populate_key(hsm_info, hsm_info->device_path, hsm_info->sim_pin) != 0) {
           (void)fprintf(stderr, "Failed reading key\r\n");
           result = NULL;
         }
       }
 
-      if (hsm_info->key == NULL)
-      {
+      if (hsm_info->key == NULL) {
         result = NULL;
-      }
-      else
-      {
+      } else {
         // TODO: Malloc the private key for the iothub sdk to free
         // this value will be sent unmodified to the tlsio
         // layer to be processed
         size_t len = strlen(hsm_info->key);
-        if ((result = (char*)malloc(len + 1)) == NULL)
-        {
+        if ((result = (char*)malloc(len + 1)) == NULL) {
           (void)fprintf(stderr, "Failure allocating private key\r\n");
           result = NULL;
-        }
-        else
-        {
+        } else {
           strcpy(result, hsm_info->key);
         }
       }
-    }
-    else
-    {
+    } else {
       result = NULL;
     }
   }
-return result;
+  return result;
 }
 
-static TLSIO_CRYPTODEV_PKEY* custom_hsm_get_key_cryptodev(HSM_CLIENT_HANDLE handle)
-{
+static TLSIO_CRYPTODEV_PKEY* custom_hsm_get_key_cryptodev(HSM_CLIENT_HANDLE handle) {
   TLSIO_CRYPTODEV_PKEY* result;
-  if (handle == NULL)
-  {
+  if (handle == NULL) {
     (void)fprintf(stderr, "Invalid handle value specified\r\n");
     result = NULL;
-  }
-  else
-  {
+  } else {
     TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info = (TWILIO_TRUST_ONBOARD_HSM_INFO*)handle;
     if (hsm_info->signing) {
-      if (hsm_info->signing_key == NULL)
-      {
+      if (hsm_info->signing_key == NULL) {
         if (populate_signing_key(hsm_info, hsm_info->device_path, hsm_info->sim_pin) != 0) {
           (void)fprintf(stderr, "Failed reading key\r\n");
           result = NULL;
@@ -358,109 +314,76 @@ static TLSIO_CRYPTODEV_PKEY* custom_hsm_get_key_cryptodev(HSM_CLIENT_HANDLE hand
       }
 
       result = hsm_info->signing_key;
-    }
-    else
-    {
+    } else {
       result = NULL;
     }
   }
-return result;
+  return result;
 }
 
-static char* custom_hsm_get_common_name(HSM_CLIENT_HANDLE handle)
-{
-    char* result;
-    if (handle == NULL)
-    {
-        (void)fprintf(stderr, "Invalid handle value specified\r\n");
-        result = NULL;
-    }
-    else
-    {
-        TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info = (TWILIO_TRUST_ONBOARD_HSM_INFO*)handle;
-        if (hsm_info->common_name == NULL)
-        {
-          if (populate_cert(hsm_info, hsm_info->device_path, hsm_info->sim_pin) != 0) {
-            (void)fprintf(stderr, "Failed reading certificate\r\n");
-            result = NULL;
-          }
-        }
-        
-        if (hsm_info->common_name == NULL)
-        {
-          result = NULL;
-        }
-        else
-        {
-          // TODO: Malloc the common name for the iothub sdk to free
-          // this value will be sent to dps
-          size_t len = strlen(hsm_info->common_name);
-          if ((result = (char*)malloc(len + 1)) == NULL)
-          {
-            (void)fprintf(stderr, "Failure allocating certificate\r\n");
-            result = NULL;
-          }
-          else
-          {
-            strcpy(result, hsm_info->common_name);
-          }
-        }
-    }
-    return result;
-}
-
-static int custom_hsm_set_data(HSM_CLIENT_HANDLE handle, const void* data)
-{
-  int result;
-  if (handle == NULL)
-  {
-	(void)fprintf(stderr, "Invalid handle value specified\r\n");
-	result = __LINE__;
-  }
-  else
-  {
-  	// Cast to the data and store it as necessary
+static char* custom_hsm_get_common_name(HSM_CLIENT_HANDLE handle) {
+  char* result;
+  if (handle == NULL) {
+    (void)fprintf(stderr, "Invalid handle value specified\r\n");
+    result = NULL;
+  } else {
     TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info = (TWILIO_TRUST_ONBOARD_HSM_INFO*)handle;
-  	TWILIO_TRUST_ONBOARD_HSM_CONFIG* config = (TWILIO_TRUST_ONBOARD_HSM_CONFIG*)data;
-    hsm_info->device_path = strdup(config->device_path);
-    hsm_info->sim_pin = strdup(config->sim_pin);
-    hsm_info->signing = config->signing;
-    result = 0;
+    if (hsm_info->common_name == NULL) {
+      if (populate_cert(hsm_info, hsm_info->device_path, hsm_info->sim_pin) != 0) {
+        (void)fprintf(stderr, "Failed reading certificate\r\n");
+        result = NULL;
+      }
+    }
+
+    if (hsm_info->common_name == NULL) {
+      result = NULL;
+    } else {
+      // TODO: Malloc the common name for the iothub sdk to free
+      // this value will be sent to dps
+      size_t len = strlen(hsm_info->common_name);
+      if ((result = (char*)malloc(len + 1)) == NULL) {
+        (void)fprintf(stderr, "Failure allocating certificate\r\n");
+        result = NULL;
+      } else {
+        strcpy(result, hsm_info->common_name);
+      }
+    }
+  }
+  return result;
+}
+
+static int custom_hsm_set_data(HSM_CLIENT_HANDLE handle, const void* data) {
+  int result;
+  if (handle == NULL) {
+    (void)fprintf(stderr, "Invalid handle value specified\r\n");
+    result = __LINE__;
+  } else {
+    // Cast to the data and store it as necessary
+    TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info = (TWILIO_TRUST_ONBOARD_HSM_INFO*)handle;
+    TWILIO_TRUST_ONBOARD_HSM_CONFIG* config = (TWILIO_TRUST_ONBOARD_HSM_CONFIG*)data;
+    hsm_info->device_path                   = strdup(config->device_path);
+    hsm_info->sim_pin                       = strdup(config->sim_pin);
+    hsm_info->signing                       = config->signing;
+    result                                  = 0;
   }
   return result;
 }
 
 // Defining the v-table for the x509 hsm calls
-static const HSM_CLIENT_X509_INTERFACE x509_interface =
-{
-    custom_hsm_create,
-    custom_hsm_destroy,
-    custom_hsm_get_certificate,
-    custom_hsm_get_key,
-    custom_hsm_get_key_cryptodev,
-    custom_hsm_get_common_name,
-    custom_hsm_set_data 
-};
+static const HSM_CLIENT_X509_INTERFACE x509_interface = {
+    custom_hsm_create,  custom_hsm_destroy,           custom_hsm_get_certificate,
+    custom_hsm_get_key, custom_hsm_get_key_cryptodev, custom_hsm_get_common_name,
+    custom_hsm_set_data};
 
-static const HSM_CLIENT_TPM_INTERFACE tpm_interface =
-{
-    custom_hsm_create,
-    custom_hsm_destroy,
-    NULL,
-    NULL,
-    NULL,
-    NULL,
-    custom_hsm_set_data 
-};
+static const HSM_CLIENT_TPM_INTERFACE tpm_interface = {custom_hsm_create,  custom_hsm_destroy, NULL, NULL, NULL, NULL,
+                                                       custom_hsm_set_data};
 
-const HSM_CLIENT_X509_INTERFACE* hsm_client_x509_interface()
-{
-    // x509 interface pointer
-    return &x509_interface;
+const HSM_CLIENT_X509_INTERFACE* hsm_client_x509_interface() {
+  // x509 interface pointer
+  return &x509_interface;
 }
 
-const HSM_CLIENT_TPM_INTERFACE* hsm_client_tpm_interface()
-{
-    // tpm interface pointer
-    return &tpm_interface;
+const HSM_CLIENT_TPM_INTERFACE* hsm_client_tpm_interface() {
+  // tpm interface pointer
+  return &tpm_interface;
 }

--- a/cloud-support/azure-iot/azure-iot-sdk-c/custom_hsm_twilio.h
+++ b/cloud-support/azure-iot/azure-iot-sdk-c/custom_hsm_twilio.h
@@ -14,4 +14,5 @@
 typedef struct TWILIO_TRUST_ONBOARD_HSM_CONFIG_TAG {
   const char* device_path;
   const char* sim_pin;
+  int signing;
 } TWILIO_TRUST_ONBOARD_HSM_CONFIG;

--- a/cloud-support/azure-iot/python_tob_helper/CMakeLists.txt
+++ b/cloud-support/azure-iot/python_tob_helper/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.7)
 # cmake -DMODULE_DEVICE="/dev/cu.usbmodem14103" -DSIM_PIN="0000" ..
 # cmake -DMODULE_DEVICE="/dev/ttyACM1" -DSIM_PIN="0000" ..
 
+option (USE_SIGNING "Use signing key and certificate" ON)
+
 if (NOT MODULE_DEVICE)
   set(MODULE_DEVICE "/dev/ttyACM1")
 endif()
@@ -18,6 +20,10 @@ endif()
 add_definitions(-DMODULE_DEVICE="${MODULE_DEVICE}")
 add_definitions(-DSIM_PIN="${SIM_PIN}")
 add_definitions(-DAZURE_ID_SCOPE_PATH="${AZURE_ID_SCOPE_PATH}")
+
+if (USE_SIGNING)
+  add_definitions(-DUSE_SIGNING)
+endif (USE_SIGNING)
 
 set(TOOL_BINARY python_tob_helper)
 

--- a/include/BreakoutTrustOnboardSDK.h
+++ b/include/BreakoutTrustOnboardSDK.h
@@ -22,6 +22,30 @@
 #define PEM_BUFFER_SIZE 10 * 1024
 #define DER_BUFFER_SIZE 2 * 1024
 
+#define TOB_MD_SHA1   0x10
+#define TOB_MD_SHA224 0x30
+#define TOB_MD_SHA256 0x40
+#define TOB_MD_SHA384 0x50
+
+#define TOB_ALGO_RSA_ISO9796_2 0x01
+#define TOB_ALGO_RSA_PKCS1     0x02
+#define TOB_ALGO_RSA_RFC_2409  0x03
+
+typedef enum {
+  TOB_ALGO_SHA1_RSA_PKCS1       = TOB_ALGO_RSA_PKCS1 | TOB_MD_SHA1,
+  TOB_ALGO_SHA224_RSA_PKCS1     = TOB_ALGO_RSA_PKCS1 | TOB_MD_SHA224,
+  TOB_ALGO_SHA256_RSA_PKCS1     = TOB_ALGO_RSA_PKCS1 | TOB_MD_SHA256,
+  TOB_ALGO_SHA384_RSA_PKCS1     = TOB_ALGO_RSA_PKCS1 | TOB_MD_SHA384,
+  TOB_ALGO_SHA1_RSA_ISO9796_2   = TOB_ALGO_RSA_ISO9796_2 | TOB_MD_SHA1,
+  TOB_ALGO_SHA224_RSA_ISO9796_2 = TOB_ALGO_RSA_ISO9796_2 | TOB_MD_SHA224,
+  TOB_ALGO_SHA256_RSA_ISO9796_2 = TOB_ALGO_RSA_ISO9796_2 | TOB_MD_SHA256,
+  TOB_ALGO_SHA384_RSA_ISO9796_2 = TOB_ALGO_RSA_ISO9796_2 | TOB_MD_SHA384,
+  TOB_ALGO_SHA1_RSA_RFC_2409    = TOB_ALGO_RSA_RFC_2409 | TOB_MD_SHA1,
+  TOB_ALGO_SHA224_RSA_RFC_2409  = TOB_ALGO_RSA_RFC_2409 | TOB_MD_SHA224,
+  TOB_ALGO_SHA256_RSA_RFC_2409  = TOB_ALGO_RSA_RFC_2409 | TOB_MD_SHA256,
+  TOB_ALGO_SHA384_RSA_RFC_2409  = TOB_ALGO_RSA_RFC_2409 | TOB_MD_SHA384,
+} tob_algorithm_t;
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -99,6 +123,34 @@ extern int tobExtractAvailablePrivateKeyAsPem(uint8_t *pk, int *pk_size, const c
  *   ERR_SE_EF_VERIFY_PIN_ERROR
  */
 extern int tobExtractSigningCertificate(uint8_t *cert, int *cert_size, const char *pin);
+
+/**
+ * Sign a message digest with a signing key
+ * @param algorithm - signing algoritm and digest to use
+ * @param hash - digest to sign
+ * @param hash_len - length of the digest in bytes
+ * @param signature - signature output buffer (allocate a large enough in advance!)
+ * @param signature_len - length of the signature in bytes
+ * @param pin - PIN1 for access to certificate.  Must be correct or SIM may be locked after repeated attempts.
+ * @return 0 if successful, otherwise one of the following error codes:
+ *   ERR_SE_BAD_KEY_NAME_ERROR
+ *   ERR_SE_EF_VERIFY_PIN_ERROR
+ */
+extern int tobSigningSign(tob_algorithm_t algorithm, const uint8_t *hash, int hash_len, uint8_t* signature, int* signature_len, const char* pin);
+
+/**
+ * Decrypt data with a signing key
+ * @param cipher - data to decrypt
+ * @param cipher_len - length of the data
+ * @param plain - buffer for the decrypted data (allocate a large enough in advance!)
+ * @param plain_len - length of the decrypted data in bytes
+ * @param pin - PIN1 for access to certificate.  Must be correct or SIM may be locked after repeated attempts.
+ * @return 0 if successful, otherwise one of the following error codes:
+ *   ERR_SE_BAD_KEY_NAME_ERROR
+ *   ERR_SE_EF_VERIFY_PIN_ERROR
+ */
+
+extern int tobSigningDecrypt(const uint8_t *cipher, int cipher_len, uint8_t* plain, int* plain_len, const char* pin);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Testing can be a bit of a mess, because forks in my repo should be used for c-utility and uhttp.

So the procedure is the following:

* Checkout the fork recursively: git@github.com:OYTIS/azure-iot-sdk-c.git Default branch should be already set up correctly.
* Go to c-utility, add my fork (git@github.com:OYTIS/azure-c-shared-utility.git) as a remote, and checkout `cryptodev` branch.
* Go back to `../uhttp`, add my fork (git@github.com:OYTIS/azure-uhttp-c.git) as a remote, and checkout `cryptodev` branch.
* Finally, under `uhttp` go to `deps/c-utility` and retarget it to my fork, branch `cryptodev` again.

Now everything is set to build the Azure SDK. As before build it as `cmake -Duse_openssl:bool=ON -Duse_prov_client=ON -Dbuild_provisioning_service_client=ON -Ddont_use_uploadtoblob=ON ..`, and install it.

After that Breakout SDK should be built with `-DBUILD_SHARED=ON` and whatever other options are desired (e.g. `-DPCSC_SUPPORT=ON`) and installed.

Finally, the python helper can be built. To test the signing key functionality, `-DUSE_SIGNING=ON` is required, other option can be use to adjust whether a card reader should be used for instance.