### PR TITLE
Add missing baud rate, default to SIGNING_KEY OFF

### DIFF
--- a/cloud-support/azure-iot/azure-iot-sdk-c/custom_hsm_twilio.cpp
+++ b/cloud-support/azure-iot/azure-iot-sdk-c/custom_hsm_twilio.cpp
@@ -198,7 +198,7 @@ static int populate_signing_key(TWILIO_TRUST_ONBOARD_HSM_INFO* hsm_info, const c
   hsm_info->signing_key->type         = TLSIO_CRYPTODEV_PKEY_TYPE_RSA;  // TODO: ECC support
   hsm_info->signing_key->private_data = hsm_info;
 
-  tobInitialize(device_path);
+  tobInitialize(device_path, 115200);
 
   return 0;
 }

--- a/cloud-support/azure-iot/python_tob_helper/CMakeLists.txt
+++ b/cloud-support/azure-iot/python_tob_helper/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.7)
 # cmake -DMODULE_DEVICE="/dev/cu.usbmodem14103" -DSIM_PIN="0000" ..
 # cmake -DMODULE_DEVICE="/dev/ttyACM1" -DSIM_PIN="0000" ..
 
-option (USE_SIGNING "Use signing key and certificate" ON)
+option (USE_SIGNING "Use signing key and certificate" OFF)
 
 if (NOT MODULE_DEVICE)
   set(MODULE_DEVICE "/dev/ttyACM1")

--- a/src/BreakoutTrustOnboardSDK.cpp
+++ b/src/BreakoutTrustOnboardSDK.cpp
@@ -47,7 +47,7 @@ typedef struct {
 
 class SelectionGuard {
  public:
-  SelectionGuard(Applet& applet, bool use_basic_channel) : applet_{applet} {
+  SelectionGuard(Applet& applet, bool use_basic_channel) : applet_(applet) {
     selected_ = applet_.select(use_basic_channel);
   }
 


### PR DESCRIPTION
Update a spot where baud rate was not being passed in.  Also update to SIGNING_KEY OFF since initial demo usage of the kit relies on the python Azure SDK which we don't have a signing key example for yet.