### PR TITLE
Introduce coverage collection for CI runs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,21 +49,21 @@ include_directories(external_libs/tob_sim/platform/pcsc/inc)
 include_directories(include)
 
 set(LIB_SOURCES
-        external_libs/tob_sim/common/src/Applet.cpp
-        external_libs/tob_sim/common/src/MF.cpp
-        external_libs/tob_sim/common/src/MIAS.cpp
-        external_libs/tob_sim/common/src/SEInterface.cpp
-        external_libs/tob_sim/common/src/base64.c
-        src/BreakoutTrustOnboardSDK.cpp
+	external_libs/tob_sim/common/src/Applet.cpp
+	external_libs/tob_sim/common/src/MF.cpp
+	external_libs/tob_sim/common/src/MIAS.cpp
+	external_libs/tob_sim/common/src/SEInterface.cpp
+	external_libs/tob_sim/common/src/base64.c
+	src/BreakoutTrustOnboardSDK.cpp
 	)
 
 set(LIB_HEADERS
-        external_libs/tob_sim/common/inc/ISO7816.h
-        external_libs/tob_sim/common/inc/Applet.h
-        external_libs/tob_sim/common/inc/MF.h
-        external_libs/tob_sim/common/inc/MIAS.h
-        external_libs/tob_sim/common/inc/SEInterface.h
-        external_libs/tob_sim/common/inc/base64.h
+	external_libs/tob_sim/common/inc/ISO7816.h
+	external_libs/tob_sim/common/inc/Applet.h
+	external_libs/tob_sim/common/inc/MF.h
+	external_libs/tob_sim/common/inc/MIAS.h
+	external_libs/tob_sim/common/inc/SEInterface.h
+	external_libs/tob_sim/common/inc/base64.h
 	)
 
 if(NOT NO_OS)
@@ -83,7 +83,7 @@ endif(NOT NO_OS)
 if(PCSC_SUPPORT)
 	find_package(PCSC REQUIRED)
 
-        set(LIB_SOURCES ${LIB_SOURCES}
+	set(LIB_SOURCES ${LIB_SOURCES}
 		external_libs/tob_sim/platform/pcsc/src/Pcsc.cpp)
 	set(LIB_HEADERS ${LIB_HEADERS}
 		external_libs/tob_sim/platform/pcsc/inc/Pcsc.h)
@@ -101,12 +101,12 @@ set_property(TARGET TwilioTrustOnboard PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 if(NOT NO_OS)
 	add_executable(
-        	${TOOL_BINARY}
-	        tools/TrustOnboardTool.cpp)
+		${TOOL_BINARY}
+		tools/TrustOnboardTool.cpp)
 
 	target_link_libraries(
-        	${TOOL_BINARY}
-        	TwilioTrustOnboard)
+		${TOOL_BINARY}
+		TwilioTrustOnboard)
 endif(NOT NO_OS)
 
 if(OPENSSL_SUPPORT)
@@ -125,14 +125,17 @@ if(MBEDTLS_SUPPORT)
 		tob_mbed SHARED
 		src/TobMbedtls.cpp)
 	target_include_directories(tob_mbed PUBLIC ${MBEDTLS_INCLUDE_DIRS})
-	target_link_libraries(tob_mbed ${MBEDTLS_LIBRARIES} TwilioTrustOnboard)
+	target_link_libraries(
+		tob_mbed
+		${MBEDTLS_LIBRARIES}
+		TwilioTrustOnboard)
 endif(MBEDTLS_SUPPORT)
 
 if(PCSC_SUPPORT)
 	target_link_libraries(
 		${TOOL_BINARY}
-                ${PCSC_LIBRARIES}
-        )
+		${PCSC_LIBRARIES}
+	)
 
 	if(BUILD_SHARED)
 		target_link_libraries(
@@ -145,19 +148,19 @@ if(PCSC_SUPPORT)
 		target_link_libraries(
 			${TOB_ENGINE}
 			${PCSC_LIBRARIES}
-	        )
+		)
 	endif(OPENSSL_SUPPORT)
 
 	if(MBEDTLS_SUPPORT)
 		target_link_libraries(
 			tob_mbed
 			${PCSC_LIBRARIES}
-	        )
+		)
 	endif(MBEDTLS_SUPPORT)
 endif(PCSC_SUPPORT)
 
 set(TOOLS_SOURCES
-        tools/TrustOnboardTool.cpp
+	tools/TrustOnboardTool.cpp
 	)
 
 if(OPENSSL_SUPPORT)
@@ -185,8 +188,8 @@ if(NOT NO_OS)
 endif(NOT NO_OS)
 
 install(FILES include/BreakoutTrustOnboardSDK.h
-	      external_libs/tob_sim/common/inc/SEInterface.h
-	      external_libs/tob_sim/common/inc/ISO7816.h
+	external_libs/tob_sim/common/inc/SEInterface.h
+	external_libs/tob_sim/common/inc/ISO7816.h
 	DESTINATION include)
 
 set(CPACK_COMPONENTS_ALL_IN_ONE_PACKAGE 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ option(OPENSSL_SUPPORT "Support for signing key with OpenSSL support" OFF)
 option(MBEDTLS_SUPPORT "Private crypto device shims for MbedTLS 2.11+" OFF)
 option(BUILD_SHARED "Build as a shared library" OFF)
 option(BUILD_TESTS "Build tests" OFF)
+option(BUILD_TESTS_COVERAGE "Build test coverage metrics" OFF)
 option(BUILD_DOCS "Build doxygen documentation" OFF)
 option(NO_OS "Build for bare metal / RTOS" OFF)
 
@@ -26,6 +27,13 @@ endif(OPENSSL_SUPPORT)
 #add_definitions(-DMODEM_DEBUG)
 #add_definitions(-DAPDU_DEBUG)
 #add_definitions(-DSERIAL_DEBUG)
+
+if(BUILD_TESTS_COVERAGE)
+	add_definitions(-fprofile-arcs)
+	add_definitions(-ftest-coverage)
+
+	set(COVERAGE_LIBRARIES "gcov")
+endif(BUILD_TESTS_COVERAGE)
 
 if(NO_OS)
 	add_definitions(-DNO_OS)
@@ -106,6 +114,7 @@ if(NOT NO_OS)
 
 	target_link_libraries(
 		${TOOL_BINARY}
+		${COVERAGE_LIBRARIES}
 		TwilioTrustOnboard)
 endif(NOT NO_OS)
 
@@ -116,6 +125,7 @@ if(OPENSSL_SUPPORT)
 
 	target_link_libraries(
 		${TOB_ENGINE}
+		${COVERAGE_LIBRARIES}
 		TwilioTrustOnboard)
 endif(OPENSSL_SUPPORT)
 
@@ -128,6 +138,7 @@ if(MBEDTLS_SUPPORT)
 	target_link_libraries(
 		tob_mbed
 		${MBEDTLS_LIBRARIES}
+		${COVERAGE_LIBRARIES}
 		TwilioTrustOnboard)
 endif(MBEDTLS_SUPPORT)
 
@@ -135,12 +146,14 @@ if(PCSC_SUPPORT)
 	target_link_libraries(
 		${TOOL_BINARY}
 		${PCSC_LIBRARIES}
+		${COVERAGE_LIBRARIES}
 	)
 
 	if(BUILD_SHARED)
 		target_link_libraries(
 			TwilioTrustOnboard
 			${PCSC_LIBRARIES}
+			${COVERAGE_LIBRARIES}
 		)
 	endif(BUILD_SHARED)
 
@@ -148,6 +161,7 @@ if(PCSC_SUPPORT)
 		target_link_libraries(
 			${TOB_ENGINE}
 			${PCSC_LIBRARIES}
+			${COVERAGE_LIBRARIES}
 		)
 	endif(OPENSSL_SUPPORT)
 
@@ -155,6 +169,7 @@ if(PCSC_SUPPORT)
 		target_link_libraries(
 			tob_mbed
 			${PCSC_LIBRARIES}
+			${COVERAGE_LIBRARIES}
 		)
 	endif(MBEDTLS_SUPPORT)
 endif(PCSC_SUPPORT)

--- a/ci-testscript.sh
+++ b/ci-testscript.sh
@@ -3,7 +3,7 @@
 mkdir -p cmake
 mkdir -p install_prefix
 cd cmake
-cmake -DPCSC_SUPPORT=ON -DOPENSSL_SUPPORT=ON -DMBEDTLS_SUPPORT=ON -DBUILD_SHARED=ON -DBUILD_TESTS=ON -DCMAKE_INSTALL_PREFIX=../install_prefix ..
+cmake -DPCSC_SUPPORT=ON -DOPENSSL_SUPPORT=ON -DMBEDTLS_SUPPORT=ON -DBUILD_SHARED=ON -DBUILD_TESTS=ON -DBUILD_TESTS_COVERAGE=ON -DCMAKE_INSTALL_PREFIX=../install_prefix ..
 make
 make install
 
@@ -18,4 +18,7 @@ fi
 
 ../tests/scripts/test_runner.py ${MODEMS_CSV_FILE} bin/trust_onboard_sdk_tests bin/trust_onboard_ll_tests ../tests/tls_lib_test.sh
 
-
+gcov ./tests/CMakeFiles/trust_onboard_sdk_tests.dir/BreakoutTrustOnboardSDKTests.cpp.gcno ./tests/CMakeFiles/trust_onboard_sdk_tests.dir/BreakoutTrustOnboardLLTests.cpp.gcno ./CMakeFiles/TwilioTrustOnboard.dir/src/BreakoutTrustOnboardSDK.cpp.gcno
+lcov --capture --directory .. --output-file raw_main_coverage.info
+lcov --remove raw_main_coverage.info '*/catch.hpp' '/usr/*' --output-file main_coverage.info
+lcov --list main_coverage.info

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,12 +23,14 @@ add_executable(
 target_link_libraries(
 	trust_onboard_sdk_tests
 	TwilioTrustOnboard
+	${COVERAGE_LIBRARIES}
 )
 
 target_link_libraries(
 	trust_onboard_ll_tests
 	TwilioTrustOnboard
 	${OPENSSL_LIBRARIES}
+	${COVERAGE_LIBRARIES}
 )
 
 
@@ -36,11 +38,13 @@ if(PCSC_SUPPORT)
 	target_link_libraries(
 		trust_onboard_sdk_tests
 		${PCSC_LIBRARIES}
+		${COVERAGE_LIBRARIES}
 	)
 
 	target_link_libraries(
 		trust_onboard_ll_tests
 		${PCSC_LIBRARIES}
+		${COVERAGE_LIBRARIES}
 	)
 endif(PCSC_SUPPORT)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,36 +11,36 @@ find_package(OpenSSL REQUIRED)
 include_directories(${OPENSSL_INCLUDE_DIR})
 
 add_executable(
-  trust_onboard_sdk_tests
-  BreakoutTrustOnboardSDKTests.cpp
-  )
+	trust_onboard_sdk_tests
+	BreakoutTrustOnboardSDKTests.cpp
+)
 
 add_executable(
-  trust_onboard_ll_tests
-  BreakoutTrustOnboardLLTests.cpp
-  )
+	trust_onboard_ll_tests
+	BreakoutTrustOnboardLLTests.cpp
+)
 
 target_link_libraries(
-  trust_onboard_sdk_tests
-  TwilioTrustOnboard
-  )
+	trust_onboard_sdk_tests
+	TwilioTrustOnboard
+)
 
 target_link_libraries(
-  trust_onboard_ll_tests
-  TwilioTrustOnboard
-  ${OPENSSL_LIBRARIES}
-  )
+	trust_onboard_ll_tests
+	TwilioTrustOnboard
+	${OPENSSL_LIBRARIES}
+)
 
 
 if(PCSC_SUPPORT)
-  target_link_libraries(
-    trust_onboard_sdk_tests
-    ${PCSC_LIBRARIES}
-  )
+	target_link_libraries(
+		trust_onboard_sdk_tests
+		${PCSC_LIBRARIES}
+	)
 
-  target_link_libraries(
-    trust_onboard_ll_tests
-    ${PCSC_LIBRARIES}
-  )
+	target_link_libraries(
+		trust_onboard_ll_tests
+		${PCSC_LIBRARIES}
+	)
 endif(PCSC_SUPPORT)
 


### PR DESCRIPTION
Adds gcov collection and lcov reporting to ci-testscripts.sh job.  Requires `gcov` and `lcov` to be installed.  You can locally make an interactive html output to see what specific code is covered/not covered by running that script (or manually running the gcov/lcov commands) with `genhtml main_coverage.info --output-directory out`