### PR TITLE
Include openssl/pem.h in openssl engine source

### DIFF
--- a/tools/OpenSSLEngine.cpp
+++ b/tools/OpenSSLEngine.cpp
@@ -1,5 +1,6 @@
 #include <string.h>
 #include <openssl/engine.h>
+#include <openssl/pem.h>
 
 #include "BreakoutTrustOnboardSDK.h"
 


### PR DESCRIPTION
Fixes build error on older OpenSSL versions where it is not included in
engine.h

Signed-off-by: Anton Gerasimov <agerasimov@twilio.com>